### PR TITLE
Add links to Postgres Manual

### DIFF
--- a/trails/postgres.md
+++ b/trails/postgres.md
@@ -6,49 +6,47 @@ Critical learning
 
 Read these sections of the [Postgres manual](http://www.postgresql.org/docs/9.0/static/index.html):
 
-```shell
-2.5. Querying a Table
-2.6. Joins Between Tables
-2.7. Aggregate Functions
-3.5. Window Functions
-4. SQL Syntax
-  4.1. Lexical Structure
-  4.2. Value Expressions
-5. Data Definition
-  5.1. Table Basics
-  5.2. Default Values
-  5.3. Constraints
-  5.5. Modifying Tables
-6. Data Manipulation
-  6.1. Inserting Data
-  6.2. Updating Data
-  6.3. Deleting Data
-7. Queries
-  7.1. Overview
-  7.2. Table Expressions
-  7.3. Select Lists
-  7.4. Combining Queries
-  7.5. Sorting Rows
-  7.6. LIMIT and OFFSET
-  7.7. VALUES Lists
-  7.8. WITH Queries (Common Table Expressions)
-9. Functions and Operators
-  9.1. Logical Operators
-  9.2. Comparison Operators
-  9.7.1 LIKE
-  9.20 Subquery Expressions
-11. Indexes
-  11.1. Introduction
-  11.5. Combining Multiple Indexes
-I. SQL Commands
-  ALTER TABLE
-  CREATE INDEX [ CONCURRENTLY ]
-  CREATE TABLE
-  DELETE
-  INSERT
-  SELECT
-  UPDATE
-```
+* 2.5\. [Querying a Table](http://www.postgresql.org/docs/9.0/static/tutorial-select.html)
+* 2.6\. [Joins Between Tables](http://www.postgresql.org/docs/9.0/static/tutorial-join.html)
+* 2.7\. [Aggregate Functions](http://www.postgresql.org/docs/9.0/static/tutorial-agg.html)
+* 3.5\. [Window Functions](http://www.postgresql.org/docs/9.0/static/tutorial-window.html)
+* 4\. [SQL Syntax](http://www.postgresql.org/docs/9.0/static/sql-syntax.html)
+  - 4.1\. [Lexical Structure](http://www.postgresql.org/docs/9.0/static/sql-syntax-lexical.html)
+  - 4.2\. [Value Expressions](http://www.postgresql.org/docs/9.0/static/sql-expressions.html)
+* 5\. [Data Definition](http://www.postgresql.org/docs/9.0/static/ddl.html)
+  - 5.1\. [Table Basics](http://www.postgresql.org/docs/9.0/static/ddl-basics.html)
+  - 5.2\. [Default Values](http://www.postgresql.org/docs/9.0/static/ddl-default.html)
+  - 5.3\. [Constraints](http://www.postgresql.org/docs/9.0/static/ddl-constraints.html)
+  - 5.5\. [Modifying Tables](http://www.postgresql.org/docs/9.0/static/ddl-alter.html)
+* 6\. [Data Manipulation](http://www.postgresql.org/docs/9.0/static/dml.html)
+  * 6.1\. [Inserting Data](http://www.postgresql.org/docs/9.0/static/dml-insert.html)
+  * 6.2\. [Updating Data](http://www.postgresql.org/docs/9.0/static/dml-update.html)
+  * 6.3\. [Deleting Data](http://www.postgresql.org/docs/9.0/static/dml-delete.html)
+* 7\. [Queries](http://www.postgresql.org/docs/9.0/static/queries.html)
+  * 7.1\. [Overview](http://www.postgresql.org/docs/9.0/static/queries-overview.html)
+  * 7.2\. [Table Expressions](http://www.postgresql.org/docs/9.0/static/queries-table-expressions.html)
+  * 7.3\. [Select Lists](http://www.postgresql.org/docs/9.0/static/queries-select-lists.html)
+  * 7.4\. [Combining Queries](http://www.postgresql.org/docs/9.0/static/queries-union.html)
+  * 7.5\. [Sorting Rows](http://www.postgresql.org/docs/9.0/static/queries-order.html)
+  * 7.6\. [LIMIT and OFFSET](http://www.postgresql.org/docs/9.0/static/queries-limit.html)
+  * 7.7\. [VALUES Lists](http://www.postgresql.org/docs/9.0/static/queries-values.html)
+  * 7.8\. [WITH Queries (Common Table Expressions)](http://www.postgresql.org/docs/9.0/static/queries-with.html)
+* 9\. [Functions and Operators](http://www.postgresql.org/docs/9.0/static/functions.html)
+  * 9.1\. [Logical Operators](http://www.postgresql.org/docs/9.0/static/functions-logical.html)
+  * 9.2\. [Comparison Operators](http://www.postgresql.org/docs/9.0/static/functions-comparison.html)
+  * 9.7.1\. [LIKE](http://www.postgresql.org/docs/9.0/static/functions-matching.html#FUNCTIONS-LIKE)
+  * 9.20\.[Subquery Expressions](http://www.postgresql.org/docs/9.0/static/functions-subquery.html)
+* 11\. [Indexes](http://www.postgresql.org/docs/9.0/static/indexes.html)
+  * 11.1\. [Introduction](http://www.postgresql.org/docs/9.0/static/indexes-intro.html)
+  * 11.5\. [Combining Multiple Indexes](http://www.postgresql.org/docs/9.0/static/indexes-bitmap-scans.html)
+* I. [SQL Commands](http://www.postgresql.org/docs/9.0/static/sql-commands.html)
+  * [ALTER TABLE](http://www.postgresql.org/docs/9.0/static/sql-altertable.html)
+  * [CREATE INDEX [ CONCURRENTLY ]](http://www.postgresql.org/docs/9.0/static/sql-createindex.html)
+  * [CREATE TABLE](http://www.postgresql.org/docs/9.0/static/sql-createtable.html)
+  * [DELETE](http://www.postgresql.org/docs/9.0/static/sql-delete.html)
+  * [INSERT](http://www.postgresql.org/docs/9.0/static/sql-insert.html)
+  * [SELECT](http://www.postgresql.org/docs/9.0/static/sql-select.html)
+  * [UPDATE](http://www.postgresql.org/docs/9.0/static/sql-update.html)
 
 Read the following sections of the [SQL Cookbook](http://www.amazon.com/Cookbook-Cookbooks-OReilly-Anthony-Molinaro/dp/0596009763): ($)
 


### PR DESCRIPTION
Link directly to the referenced portion of the Postgres Manual, for more
convenient navigation.
