### PR TITLE
Corrected Contributing Guidlines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use these, you may want to first set up your laptop with
 Contributing
 ------------
 
-Please see [Contribution Guidelines](/thoughtbot/trail-map/blob/master/trails/CONTRIBUTING.md)
+Please see [Contribution Guidelines](/thoughtbot/trail-map/blob/master/CONTRIBUTING.md)
 
 Credits
 -------


### PR DESCRIPTION
Noticed when I looked through the README. The link was 404ing. Fixed now.
