### PR TITLE
Add community driven Ruby style guide

### DIFF
--- a/trails/ruby.md
+++ b/trails/ruby.md
@@ -44,4 +44,4 @@ Ongoing Reference
 
 * [Ruby Core Documentation](http://ruby-doc.org/core-1.9.3)
 * Ruby Library reference in The Pickaxe.
-* Stick to a [style](https://github.com/bbatsov/ruby-style-guide) [guide](http://build.thoughtbot.com/style-guide)
+* Stick to [a](https://github.com/styleguide/ruby) [style](https://github.com/bbatsov/ruby-style-guide) [guide](http://build.thoughtbot.com/style-guide)


### PR DESCRIPTION
The [community driven](https://github.com/bbatsov/ruby-style-guide) style guide has many illustrated examples and can accept pull requests.
