### PR TITLE
Fix error "Code Academy" --> "Codecademy"

### DIFF
--- a/trails/html.md
+++ b/trails/html.md
@@ -5,7 +5,7 @@ Critical learning
 -----------------
 
 * Read [A Beginner’s Guide to HTML & CSS](http://learn.shayhowe.com/).
-* Complete [Code Academy Web Fundamentals](http://www.codecademy.com/tracks/web).
+* Complete [Codecademy Web Fundamentals](http://www.codecademy.com/tracks/web).
 * Read [Dive into HTML5](http://diveintohtml5.info/).
 * Read [HTML5 for Web Designers](http://www.abookapart.com/products/html5-for-web-designers). ($)
 


### PR DESCRIPTION
Correct text "Code Academy" to "Codecademy".
