### PR TITLE
[#85] Update link to Ruby Core API

### DIFF
--- a/trails/ruby.json
+++ b/trails/ruby.json
@@ -56,7 +56,7 @@
       "resources": [
         {
           "title": "Ruby Core Documentation",
-          "uri": "http://ruby-doc.org/core-1.9.3"
+          "uri": "http://ruby-doc.org/core"
         },
         {
           "title": "Ruby Library reference in The Pickaxe",


### PR DESCRIPTION
Update Ruby trail to link to current Ruby core documentation
