### PR TITLE
Change Vim resources to hash

### DIFF
--- a/trails/vim.json
+++ b/trails/vim.json
@@ -58,12 +58,24 @@
     {
       "name": "Ongoing Reference",
       "resources": [
-        ":help",
-        ":help g",
-        ":help motion.txt",
-        ":help spell.txt",
-        ":help user-manual",
-        ":help visual.txt"
+        {
+          "title": ":help"
+        },
+        {
+          "title": ":help g"
+        },
+        {
+          "title": ":help motion.txt"
+        },
+        {
+          "title": ":help spell.txt"
+        },
+        {
+          "title": ":help user-manual"
+        },
+        {
+          "title": ":help visual.txt"
+        }
       ],
       "validations": [
         "Identify vim's use of every letter on the keyboard (uppercase and lowercase)."

--- a/trails/web-design.json
+++ b/trails/web-design.json
@@ -77,7 +77,7 @@
       ]
       },
     {
-      "name": "On going resources and magazines",
+      "name": "Ongoing resources and magazines",
       "resources": [
         {
           "title": "A List Apart",


### PR DESCRIPTION
Vim's resources under "Ongoing Reference" was mistakenly an array instead of a hash. Also fixed typo in web-design.json.
