### PR TITLE
Update links from blip.tv to youtube

### DIFF
--- a/trails/git.json
+++ b/trails/git.json
@@ -15,7 +15,7 @@
         },
         {
           "title": "Watch the Normal Workflow gitcast",
-          "uri": "http://blip.tv/scott-chacon/c2-normal-workflow-4113486"
+          "uri": "http://www.youtube.com/watch?v=U1ayH6KLqxo"
         }
       ],
       "validations": [
@@ -41,7 +41,7 @@
       "resources": [
         {
           "title": "Watch the Distributed Workflow gitcast.",
-          "uri": "http://blip.tv/scott-chacon/c8-dist-workflow-4113615"
+          "uri": "http://www.youtube.com/watch?v=KWNIKb6sftw"
         },
         {
           "title": "Read Chapter 3 of Pro Git",


### PR DESCRIPTION
- Scott Chacon's talks have moved from blip.tv to youtube
