### PR TITLE
Rescue all head errors

### DIFF
--- a/lib/helpers/uri_validator.rb
+++ b/lib/helpers/uri_validator.rb
@@ -28,7 +28,7 @@ class URIValidator
   def head_request_ok?(uri)
     response = HTTParty.head(uri)
     return response.ok?
-  rescue SocketError
+  rescue
     return false
   end
 


### PR DESCRIPTION
- Some errors while checking a uri's head were failing due to malformed html
- Rescuing all errors returns false for any reason, so as long as the `get` works, the uri will pass
