### PR TITLE
Fix typo in Rails trail

### DIFF
--- a/trails/rails.json
+++ b/trails/rails.json
@@ -54,7 +54,7 @@
           "id": "3ba2c5763b8f860458e4bb66cf76db3083251674"
         },
         {
-          "title": "Create a form that save records.",
+          "title": "Create a form that saves records.",
           "id": "36c5c9de6c7aff49b83a0a45780a45c82a805c25"
         },
         {


### PR DESCRIPTION
Change "Create a form that save records" to "Create a form that saves records".
