### PR TITLE
Add iBooks link information to Amazon books

### DIFF
--- a/trails/design.json
+++ b/trails/design.json
@@ -8,22 +8,26 @@
         {
           "title": "Read 'Visual Grammar' for an introduction to visual principles of design",
           "uri": "http://amzn.to/visual-grammar",
-          "id": "569fd51c972e75cab47fa7d6f96b0d90434502a8"
+          "id": "569fd51c972e75cab47fa7d6f96b0d90434502a8",
+          "ibook": "n/a"
         },
         {
           "title": "Read 'Grid Systems: Principles of Organizing Type' for an introduction to grid systems",
           "uri": "http://amzn.to/grid-systems-principles",
-          "id": "9ba03a7b939dba2e2c2fa3ca731732bb2caf489a"
+          "id": "9ba03a7b939dba2e2c2fa3ca731732bb2caf489a",
+          "ibook": "n/a"
         },
         {
           "title": "Read 'Thinking with Type' for an introduction to Typography",
           "uri": "http://amzn.to/thinking-with-type",
-          "id": "47d56ab5c431e1ff8ce9625f554f4ed04be05c7a"
+          "id": "47d56ab5c431e1ff8ce9625f554f4ed04be05c7a",
+          "ibook": "n/a"
         },
         {
-          "title": "Read 'Understanding Color: An Introduction for Designers' for an inroduction to Color theory",
+          "title": "Read 'Understanding Color: An Introduction for Designers' for an introduction to Color theory",
           "uri": "http://amzn.com/0470381353",
-          "id": "2b95b6d8d58a123d8dff9b92b20c4067d33f1aa3"
+          "id": "2b95b6d8d58a123d8dff9b92b20c4067d33f1aa3",
+          "ibook": "understanding-color/id493857267?mt=11"
         }
       ],
       "validations": [
@@ -32,7 +36,7 @@
           "id": "e43a99a238057032981374ed6bdd1434b8c2f007"
         },
         {
-          "title": "Use visual priciples in your design",
+          "title": "Use visual principles in your design",
           "id": "18e6c9ca27e9e0b25d19eb13c6e9e96b0bbda1fe"
         },
         {

--- a/trails/grids.json
+++ b/trails/grids.json
@@ -11,12 +11,14 @@
         {
           "title": "Grid Systems: Principles of Organizing Type",
           "uri": "http://amzn.to/grid-systems-principles",
-          "id": "3f12888626bdd8a9a81094705bdd514ea7495cdd"
+          "id": "3f12888626bdd8a9a81094705bdd514ea7495cdd",
+          "ibook": "n/a"
         },
         {
           "title": "Grid Systems in Graphic Design",
           "uri": "http://amzn.to/grid-systems-graphic-design",
-          "id": "e4c25a601f0284febaef14aa155d3ad05da8cfa0"
+          "id": "e4c25a601f0284febaef14aa155d3ad05da8cfa0",
+          "ibook": "n/a"
         },
         {
           "title": "Mark Boulton's Designing Grid Systems",
@@ -26,12 +28,14 @@
         {
           "title": "Ordering Disorder: Grid Principles for Web Design",
           "uri": "http://amzn.to/ordering-disorder",
-          "id": "46e5287ed0102dc377d71ad27c3edf96d1063e67"
+          "id": "46e5287ed0102dc377d71ad27c3edf96d1063e67",
+          "ibook": "ordering-disorder-grid-principles/id406937632?mt=11"
         },
         {
           "title": "Geometry of Design: Studies in Proportion and Composition",
           "uri": "http://amzn.to/geometry-design",
-          "id": "0c28b00f2c4bd526f51945a545817243adc94dee"
+          "id": "0c28b00f2c4bd526f51945a545817243adc94dee",
+          "ibook": "n/a"
         }
       ],
       "validations": [

--- a/trails/html-css.json
+++ b/trails/html-css.json
@@ -8,7 +8,8 @@
         {
           "title": "HTML and CSS: Design and Build Websites",
           "uri": "http://amzn.com/1118008189",
-          "id": "78104f92a0cf0f81269801f2e34f846308c364bb"
+          "id": "78104f92a0cf0f81269801f2e34f846308c364bb",
+          "ibook": "n/a"
         },
         {
           "title": "Read A Beginner’s Guide to HTML & CSS",
@@ -18,7 +19,13 @@
         {
           "title": "Read Bulletproof Web Design: Improving flexibility and protecting against worst-case scenarios with HTML5 and CSS3 for an introduction to HTML and CSS",
           "uri": "http://amzn.com/0321808355",
-          "id": "a723d16963fd6729516393433bbd9b901f489395"
+          "id": "a723d16963fd6729516393433bbd9b901f489395",
+          "ibook": "bulletproof-web-design-improving/id483421070?mt=11"
+        },
+        {
+          "title": "Complete Code Academy Web Fundamentals",
+          "uri": "http://www.codecademy.com/tracks/web",
+          "id": "1d8fbe7bbe0a30ebc78468131b468d0a3e5f95e0"
         }
       ],
       "validations": [
@@ -57,27 +64,24 @@
       ]
     },
     {
-      "name": "Run through the tutorials at Code Academy",
-      "references": [
-        {
-          "title": "Complete Code Academy Web Fundamentals",
-          "uri": "http://www.codecademy.com/tracks/web",
-          "id": "1d8fbe7bbe0a30ebc78468131b468d0a3e5f95e0"
-        }
-      ]
-    },
-    {
       "name": "Dig deeper into HTML5",
-      "references": [
+      "resources": [
         {
           "title": "Read Dive into HTML5",
           "uri": "http://diveintohtml5.info/",
-          "id": "8e3df4e84e67f47a66682bd9f8f62498ab3c47a4"
+          "id": "8e3df4e84e67f47a66682bd9f8f62498ab3c47a4",
+          "ibook": "html5-up-and-running/id394890993?mt=11"
         },
         {
           "title": "Read HTML5 for Web Designers",
           "uri": "http://www.abookapart.com/products/html5-for-web-designers",
-          "id": "5e950567968695a6ee06d185d7f9cfa0d0ac5759"
+          "id": "5e950567968695a6ee06d185d7f9cfa0d0ac5759",
+          "ibook": "html5-for-web-designers/id391397649?mt=11"
+        },
+        {
+          "title": "Refer to the HTML5 Spec",
+          "uri": "http://dev.w3.org/html5/spec/single-page.html",
+          "id": "3d72ce80d850495ec111602c8b2bf7e628020be8"
         }
       ],
       "validations": [
@@ -97,11 +101,12 @@
     },
     {
       "name": "Dig deeper into CSS3",
-      "references": [
+      "resources": [
         {
           "title": "CSS3 for Web Designers",
           "uri": "http://www.abookapart.com/products/css3-for-web-designers",
-          "id": "d9d3c1d41c0963ae1de6ae2f041365813d88176e"
+          "id": "d9d3c1d41c0963ae1de6ae2f041365813d88176e",
+          "ibook": "css3-for-web-designers/id405582149?mt=11"
         },
         {
           "title": "Refer to CSS3.info",
@@ -119,7 +124,7 @@
           "id": "a472be29ea68bada79c1255738bd9e06649b9d15"
         },
         {
-          "title": "Know trasitsions and animations and where to apply them",
+          "title": "Know transitions and animations and where to apply them",
           "id": "d0d046d4e4db8b1544f78a6c611948a47e297f57"
         },
         {
@@ -131,14 +136,14 @@
           "id": "3c4010eaa87bb3a1e1bfa2977109b3b7aab0a66c"
         },
         {
-          "title": "Know the new psuedo-selectors and know their uses",
+          "title": "Know the new pseudo-selectors and know their uses",
           "id": "aecf8e1709cd0d7072fefd09c1b422664d7cb4a9"
         }
       ]
     },
     {
       "name": "Learn about responsive and mobile first design",
-      "references": [
+      "resources": [
         {
           "title": "Read Responsive Web Design the article",
           "uri": "http://www.alistapart.com/articles/responsive-web-design/",
@@ -147,7 +152,8 @@
         {
           "title": "Read Responsive Web Design the book",
           "uri": "http://www.abookapart.com/products/responsive-web-design",
-          "id": "f32ba296eea9e93c120b3a6698ff13be76582027"
+          "id": "f32ba296eea9e93c120b3a6698ff13be76582027",
+          "ibook": "responsive-web-design/id442160521?mt=11"
         },
         {
           "title": "Visit This is Responsive for current news and links about responsive design",
@@ -157,10 +163,11 @@
         {
           "title": "Read Mobile First",
           "uri": "http://www.abookapart.com/products/mobile-first",
-          "id": "8de6212fb3307996e460157f07d4a75fea10aa62"
+          "id": "8de6212fb3307996e460157f07d4a75fea10aa62",
+          "ibook": "mobile-first/id474052405?mt=11"
         },
         {
-          "title": "Read The Infinate Grid",
+          "title": "Read The Infinite Grid",
           "uri": "http://www.alistapart.com/articles/the-infinite-grid/",
           "id": "f9dc4c08bb664482df033da47060b11e24a3aa13"
         },
@@ -190,26 +197,6 @@
         {
           "title": "Understand how best to serve images to mobile and retina screens",
           "id": "fcaa691226b6b10f3f1ded6f2218ec974566aaa4"
-        }
-      ]
-    },
-    {
-      "name": "Ongoing Reference",
-      "references": [
-        {
-          "title": "Refer to the HTML5 Spec",
-          "uri": "http://dev.w3.org/html5/spec/single-page.html",
-          "id": "3d72ce80d850495ec111602c8b2bf7e628020be8"
-        }
-      ]
-    },
-    {
-      "name": "Learn about Sass",
-      "references": [
-        {
-          "title": "Visit Sass on Learn",
-          "uri": "http://learn.thoughtbot.com/sass",
-          "id": "c0b7b53fd59586cf900e803af84c96ab854738be"
         }
       ]
     }

--- a/trails/information-design.json
+++ b/trails/information-design.json
@@ -8,22 +8,26 @@
         {
           "title": "Read Information Dashboard Design",
           "uri": "http://amzn.to/information-dashboard",
-          "id": "24af44ce985b0127da5b10a9e1b68785bd185c7c"
+          "id": "24af44ce985b0127da5b10a9e1b68785bd185c7c",
+          "ibook": "n/a"
         },
         {
           "title": "Read Envisioning Information",
           "uri": "http://amzn.to/envisioning-information",
-          "id": "97f9816c85cf36e23cd461386b80473a2381cffd"
+          "id": "97f9816c85cf36e23cd461386b80473a2381cffd",
+          "ibook": "n/a"
         },
         {
           "title": "Read The Visual Display of Quantitative Information",
           "uri": "http://amzn.to/visual-display",
-          "id": "03b18d3184731525abc721139cbdb9fbab29174c"
+          "id": "03b18d3184731525abc721139cbdb9fbab29174c",
+          "ibook": "n/a"
         },
         {
           "title": "Read A Practical Guide to Designing with Data",
           "uri": "http://www.fivesimplesteps.com/products/a-practical-guide-to-designing-with-data",
-          "id": "f1054c2ebbc53e5302cec3c8834bfe60abe464ea"
+          "id": "f1054c2ebbc53e5302cec3c8834bfe60abe464ea",
+          "ibook": "practical-guide-to-designing/id447639507?mt=11"
         }
       ],
       "validations": [

--- a/trails/ios.json
+++ b/trails/ios.json
@@ -13,12 +13,14 @@
         {
           "title": "Read Learn Objective-C on the Mac",
           "uri": "http://amzn.to/learn-objective-c-mac",
-          "id": "d39f5d5c984f65eeaa2885ff6d92d2bd64cc5352"
+          "id": "d39f5d5c984f65eeaa2885ff6d92d2bd64cc5352",
+          "ibook": "learn-objective-c-on-the-mac/id492011030?mt=11"
         },
         {
           "title": "Read Beginning iOS 5 Development: Exploring the iOS SDK",
           "uri": "http://amzn.to/beginning-ios5",
-          "id": "03bb5acb9802da5fb421bae79f5522fa5a3149dd"
+          "id": "03bb5acb9802da5fb421bae79f5522fa5a3149dd",
+          "ibook": "n/a"
         },
         {
           "title": "Read The Objective-C Programming Language",
@@ -33,7 +35,8 @@
         {
           "title": "Read chapters 6 - 15, 17 - 19, 24, 28 - 30 of Cocoa Design Patterns",
           "uri": "http://amzn.to/cocoa-design-patterns",
-          "id": "662367815cc07ed96dda948610fb639a7f7ea358"
+          "id": "662367815cc07ed96dda948610fb639a7f7ea358",
+          "ibook": "n/a"
         },
         {
           "title": "Read and hack on sample code",
@@ -52,7 +55,7 @@
           "id": "6067e99790813224305d6a60eb0da23176d5a2f3"
         },
         {
-          "title": "Describe and use ARC and MRC for memory mangement, as well as the rules of the retain/release/autorelease cycle.",
+          "title": "Describe and use ARC and MRC for memory management, as well as the rules of the retain/release/autorelease cycle.",
           "id": "24cbe27995f92ab7c2d9ff4d3b0d688d5af23593"
         },
         {
@@ -115,6 +118,7 @@
         },
         {
           "title": "Keep up-to-date on iOS news.",
+          "uri": "https://developer.apple.com/library/ios/navigation/#section=Resource%20Types&topic=Release%20Notes",
           "id": "cb9a270daef11346e642bc1d4f89712fc0bac7ee"
         },
         {

--- a/trails/javascript.json
+++ b/trails/javascript.json
@@ -70,7 +70,8 @@
         {
           "title": "JavaScript: The Definitive Guide, Core and Client-Side Reference chapters",
           "uri": "http://amzn.to/ONeSOs",
-          "id": "91b457d0144f2e8ac562ec6af040ecc10681e1c4"
+          "id": "91b457d0144f2e8ac562ec6af040ecc10681e1c4",
+          "ibook": "javascript-definitive-guide/id434078374?mt=11"
         }
       ],
       "validations": [
@@ -90,7 +91,8 @@
         {
           "title": "JavaScript Web Applications",
           "uri": "http://amzn.to/javascript-web-apps",
-          "id": "c51812e7b048fc40a36f2c19a6177eec53c6ef12"
+          "id": "c51812e7b048fc40a36f2c19a6177eec53c6ef12",
+          "ibook": "javascript-web-applications/id462427083?mt=11"
         },
         {
           "title": "jQuery API",

--- a/trails/open-source.json
+++ b/trails/open-source.json
@@ -1,6 +1,6 @@
 {
   "name": "Open Source",
-  "description": "A software philsophy that promotes free redistribution and access to source code.",
+  "description": "A software philosophy that promotes free redistribution and access to source code.",
   "prerequisites": [
     "code-review",
     "git",

--- a/trails/product-design.json
+++ b/trails/product-design.json
@@ -7,8 +7,9 @@
       "resources": [
         {
           "title": "Read \"The Lean Startup\".",
-          "uri": "http://amzn.com/1568985819",
-          "id": "1499275a8b0c3088872fe6fb85858d6630405743"
+          "uri": "http://amzn.com/0307887898",
+          "id": "1499275a8b0c3088872fe6fb85858d6630405743",
+          "ibook": "the-lean-startup/id422540072?mt=11"
         },
         {
           "title": "Read thoughtbot's \"The Playbook\".",

--- a/trails/refactoring.json
+++ b/trails/refactoring.json
@@ -91,12 +91,14 @@
         {
           "title": "Refactoring: Ruby Edition",
           "uri": "http://amzn.to/ruby-refactoring",
-          "id": "94e5e46116f1766fac1fb276e52ead5968ecfd2d"
+          "id": "94e5e46116f1766fac1fb276e52ead5968ecfd2d",
+          "ibook": "refactoring-ruby-edition/id401429800?mt=11"
         },
         {
           "title": "Refactoring to Patterns",
           "uri": "http://amzn.to/refactoring-to-patterns",
-          "id": "e1f05298c04e3bd6adf800910d2ef9718afdc802"
+          "id": "e1f05298c04e3bd6adf800910d2ef9718afdc802",
+          "ibook": "refactoring-to-patterns/id401492622?mt=11"
         }
       ]
     }

--- a/trails/ruby.json
+++ b/trails/ruby.json
@@ -18,7 +18,8 @@
         {
           "title": "Read The Well-Grounded Rubyist.",
           "uri": "http://amzn.to/grounded-rubyist",
-          "id": "c3dd3f0bdfb78932257723150ad2d59c6a691e3b"
+          "id": "c3dd3f0bdfb78932257723150ad2d59c6a691e3b",
+          "ibook": "the-well-grounded-rubyist/id402503392?mt=11"
         }
       ],
       "validations": [
@@ -68,7 +69,8 @@
         {
           "title": "Read Chapters 23 and 24 of The Pickaxe",
           "uri": "http://amzn.to/pickaxe-19",
-          "id": "7cabf8db13d4618542456504b39a0f26181eb82a"
+          "id": "7cabf8db13d4618542456504b39a0f26181eb82a",
+          "ibook": "n/a"
         }
       ],
       "validations": [
@@ -101,7 +103,8 @@
         {
           "title": "Ruby Library reference in The Pickaxe",
           "uri": "http://amzn.to/pickaxe-19",
-          "id": "4c57e7a3d587ee3f51e86fd9829fcc77b23c10a5"
+          "id": "4c57e7a3d587ee3f51e86fd9829fcc77b23c10a5",
+          "ibook": "n/a"
         },
         {
           "title": "Github's Style Guide",

--- a/trails/sass.json
+++ b/trails/sass.json
@@ -1,6 +1,6 @@
 {
   "name": "Sass",
-  "description": "A scripting language that is interpreted into CSS, that provides powerful functionality not provided by CSS live nesting, variables, and mixins.",
+  "description": "A scripting language that is interpreted into CSS and provides powerful functionality not provided by CSS like nesting, variables, and mixins.",
   "steps": [
     {
       "name": "Critical Learning",

--- a/trails/sql.json
+++ b/trails/sql.json
@@ -288,7 +288,8 @@
         {
           "title": "SQL Cookbook",
           "uri": "http://www.amazon.com/Cookbook-Cookbooks-OReilly-Anthony-Molinaro/dp/0596009763",
-          "id": "afa03a8d12570cad4565a3b2640804e14b35a106"
+          "id": "afa03a8d12570cad4565a3b2640804e14b35a106",
+          "ibook": "sql-cookbook/id396890915?mt=11"
         }
       ]
     }

--- a/trails/test-driven-development.json
+++ b/trails/test-driven-development.json
@@ -18,7 +18,8 @@
         {
           "title": "xUnit Test Patterns",
           "uri": "http://amzn.to/x-test-patterns",
-          "id": "3c4773c1bca04677a050c8d6b3284f732b60de90"
+          "id": "3c4773c1bca04677a050c8d6b3284f732b60de90",
+          "ibook": "xunit-test-patterns/id432496466?mt=11"
         }
       ],
       "validations": [
@@ -42,7 +43,8 @@
         {
           "title": "Read Test-Driven Development By Example.",
           "uri": "http://amzn.to/test-driven-dev",
-          "id": "3d478184c84fefa705d2a8a76f299e627a8a5b86"
+          "id": "3d478184c84fefa705d2a8a76f299e627a8a5b86",
+          "ibook": "n/a"
         }
       ],
       "validations": [

--- a/trails/typography.json
+++ b/trails/typography.json
@@ -11,7 +11,8 @@
         {
           "title": "Read The Elements of Typographic Style",
           "uri": "http://amzn.to/elements-typographic-style",
-          "id": "f1944a18da4d96765339e4a9d90518d1aed7842b"
+          "id": "f1944a18da4d96765339e4a9d90518d1aed7842b",
+          "ibook": "n/a"
         },
         {
           "title": "Read The Elements of Typographic Style Applied to the Web",
@@ -21,7 +22,8 @@
         {
           "title": "Read Thinking with Type",
           "uri": "http://amzn.to/thinking-with-type",
-          "id": "520bbc4236127c5c520e5aae3c36c69dbc2a0e1f"
+          "id": "520bbc4236127c5c520e5aae3c36c69dbc2a0e1f",
+          "ibook": "n/a"
         },
         {
           "title": "Read Real Web Type in Real Web Context",
@@ -46,7 +48,8 @@
         {
           "title": "Read Stop Stealing Sheep & Find Out How Type Works",
           "uri": "http://amzn.to/stop-stealing-sheep",
-          "id": "d212bf4bdc9c701b0e8b2897c2540fbf3ded8fc6"
+          "id": "d212bf4bdc9c701b0e8b2897c2540fbf3ded8fc6",
+          "ibook": "n/a"
         }
       ],
       "validations": [

--- a/trails/unix.json
+++ b/trails/unix.json
@@ -8,7 +8,8 @@
         {
           "title": "Read The Linux Programming Interface. Chapters 1,  2, 6, 8, 10, 14, 15, 18, 25, 44, 62.",
           "uri": "http://amzn.to/the-linux-programming-interface",
-          "id": "3e5e1e86286462f7740038c7998ad900080f2cbf"
+          "id": "3e5e1e86286462f7740038c7998ad900080f2cbf",
+          "ibook": "n/a"
         },
         {
           "title": "Read about I/O redirection.",

--- a/trails/vim.json
+++ b/trails/vim.json
@@ -28,7 +28,7 @@
           "id": "bed9219683c96b60757e0fb304bc80e0a30d9ab7"
         },
         {
-          "title": "Set up ctags for instanteous tab completion and jumping to method definitions.",
+          "title": "Set up ctags for instantaneous tab completion and jumping to method definitions.",
           "uri": "http://robots.thoughtbot.com/post/159805638/integrating-vim-into-your-life",
           "id": "38e74cab24e9252f141a7479da0f522fb9e4ca3c"
         },

--- a/trails/visual-principles.json
+++ b/trails/visual-principles.json
@@ -8,12 +8,14 @@
         {
           "title": "Read 'Visual Grammar' for a basic understanding on basic elements of design and how they relate to each other.",
           "uri": "http://amzn.to/visual-grammar",
-          "id": "cbee22bf1a60ae0906a63c2fb9c777d269c049b1"
+          "id": "cbee22bf1a60ae0906a63c2fb9c777d269c049b1",
+          "ibook": "n/a"
         },
         {
           "title": "Read 'Universal Principles of Design' for a larger array of principles covering an array of medium.",
           "uri": "http://amzn.to/universal-principles",
-          "id": "a93aafbb4d3a2ebbdbb9971976bde5d9bfbb6cfd"
+          "id": "a93aafbb4d3a2ebbdbb9971976bde5d9bfbb6cfd",
+          "ibook": "n/a"
         }
       ],
       "validations": [
@@ -85,7 +87,8 @@
         {
           "title": "Read '101 Things I Learned in Architecture School'",
           "uri": "http://amzn.to/101-things-learned",
-          "id": "fc030d896593cb0236380f8a0204803b98534a25"
+          "id": "fc030d896593cb0236380f8a0204803b98534a25",
+          "ibook": "101-things-i-learned-in-architecture/id562185048?mt=11"
         }
       ]
     }

--- a/trails/web-design.json
+++ b/trails/web-design.json
@@ -24,7 +24,8 @@
         {
           "title": "Read 'A Practical Guide to Designing for the Web'",
           "uri": "http://www.fivesimplesteps.com/products/a-practical-guide-to-designing-for-the-web",
-          "id": "526880b6c4998e7fa9ee2a7c00ce744d7adcc962"
+          "id": "526880b6c4998e7fa9ee2a7c00ce744d7adcc962",
+          "ibook": "practical-guide-to-designing/id447639608?mt=11"
         },
         {
           "title": "Read 'A Dao of Web Design'",
@@ -34,12 +35,14 @@
         {
           "title": "Read 'Don't Make Me Think: A Common Sense Approach to Web Usability'",
           "uri": "http://amzn.com/0321344758",
-          "id": "71cf585a0a50b7f1f6bf21df21ae53924e66d5bd"
+          "id": "71cf585a0a50b7f1f6bf21df21ae53924e66d5bd",
+          "ibook": "dont-make-me-think-common/id399578833?mt=11"
         },
         {
           "title": "Skim through 'Designing With Web Standards'",
-          "uri": "http://amzn.com/0321344758",
-          "id": "313f21abc7944875b70a03e9c96fcd9d6565f2d7"
+          "uri": "http://amzn.com/0321616952",
+          "id": "313f21abc7944875b70a03e9c96fcd9d6565f2d7",
+          "ibook": "designing-web-standards-3/id400723500?mt=11"
         },
         {
           "title": "Read 'Understanding Web Design'",
@@ -49,7 +52,7 @@
       ],
       "validations": [
         {
-          "title": "Apply basic design priciples to the web.",
+          "title": "Apply basic design principles to the web.",
           "id": "ce34e8b7ba9d4b47fa87c3a753f6e0d79358144e"
         },
         {
@@ -90,12 +93,14 @@
         {
           "title": "Read 'Rocket Surgery Made Easy: The Do-It-Yourself Guide to Finding and Fixing Usability Problems' to understand how to run a adhoc usability test.",
           "uri": "http://amzn.com/B002UXRGNO",
-          "id": "c68ff73823dd996b1917c452424a2c020366101e"
+          "id": "c68ff73823dd996b1917c452424a2c020366101e",
+          "ibook": "rocket-surgery-made-easy-do/id399580949?mt=11"
         },
         {
           "title": "Read 'The Design of Everyday Things' to see how other people have already applied user experience to real world products.",
-          "uri": "http://amzn.com/0321657292",
-          "id": "1afadd7fdabb6030c05a7b262aa15eb1c6100a94"
+          "uri": "http://amzn.com/B005JQRC7E",
+          "id": "1afadd7fdabb6030c05a7b262aa15eb1c6100a94",
+          "ibook": "the-design-of-everyday-things/id389048659?mt=11"
         },
         {
           "title": "Read through all of the weeks of '52 Weeks of UX'",


### PR DESCRIPTION
- Learn iPhone will use iBook links instead of Amazon ones
- Amazon books without iBook counterparts are marked n/a
- https://www.apptrajectory.com/thoughtbot/learn/stories/15626657
