### PR TITLE
[JQ] Remove broken link in Typography trail

### DIFF
--- a/trails/tmux.json
+++ b/trails/tmux.json
@@ -76,7 +76,8 @@
         }
       ]
     },
-    { "name": "Ongoing Reference",
+    {
+      "name": "Ongoing Reference",
       "resources": [
         {
           "title": "Read the documentation",

--- a/trails/typography.json
+++ b/trails/typography.json
@@ -15,11 +15,6 @@
           "publisher": "http://webtypography.net/bibliography/"
         },
         {
-          "title": "Read The Elements of Typographic Style Applied to the Web",
-          "uri": "http://webtypography.net",
-          "id": "c665fac4ab702ba65d531c845ce1026370d83772"
-        },
-        {
           "title": "Read Thinking with Type",
           "uri": "http://amzn.to/thinking-with-type",
           "id": "520bbc4236127c5c520e5aae3c36c69dbc2a0e1f",


### PR DESCRIPTION
- Remove resource that pointed to `webtypography.net`
- Tmux json was formatted by the validator
