### PR TITLE
makes periods consitent throughout trail-map trails

### DIFF
--- a/trails/design.json
+++ b/trails/design.json
@@ -40,39 +40,39 @@
       ],
       "validations": [
         {
-          "title": "Have a basic understanding of visual principles",
+          "title": "Have a basic understanding of visual principles.",
           "id": "e43a99a238057032981374ed6bdd1434b8c2f007"
         },
         {
-          "title": "Use visual principles in your design",
+          "title": "Use visual principles in your design.",
           "id": "18e6c9ca27e9e0b25d19eb13c6e9e96b0bbda1fe"
         },
         {
-          "title": "Communicate visual design principles in your work and others",
+          "title": "Communicate visual design principles in your work and others.",
           "id": "9677b4dcd18d47eaa4d1cb66fb094d636e0e373f"
         },
         {
-          "title": "Create and use a simple grid within your work",
+          "title": "Create and use a simple grid within your work.",
           "id": "171df1062e40f4ac0a93f49d7ef0ae3c644d52bd"
         },
         {
-          "title": "Maintain a clear hierarchy within your work",
+          "title": "Maintain a clear hierarchy within your work.",
           "id": "ea10a432aa10d6d486fe52e308b8420a57ab3cc0"
         },
         {
-          "title": "Elements in your design are aligned to the grid and have relationships to the other elements in the design",
+          "title": "Elements in your design are aligned to the grid and have relationships to the other elements in the design.",
           "id": "29d3ccaaf040a69fd8e1a203e314a8b3b1f7d788"
         },
         {
-          "title": "Are able to properly set type within your work",
+          "title": "Are able to properly set type within your work.",
           "id": "6969f19410189c5010a1cf0360a1cd1974ad1fef"
         },
         {
-          "title": "Are able to choose an adequate typeface for the message in your design",
+          "title": "Are able to choose an adequate typeface for the message in your design.",
           "id": "4116f4d2f98f35c8e4ca8fab24c7c82e938ef162"
         },
         {
-          "title": "You can assign colors to elements to add value to the message",
+          "title": "You can assign colors to elements to add value to the message.",
           "id": "39bd5cda20dc1ca899bd67c82d8203f4435ae42e"
         }
       ]

--- a/trails/git.json
+++ b/trails/git.json
@@ -24,63 +24,63 @@
       ],
       "validations": [
         {
-          "title": "Initialize a repository",
+          "title": "Initialize a repository.",
           "id": "ff25b46bc55ffd0bee25470354a56b6f21def0b5"
         },
         {
-          "title": "Clone a repository",
+          "title": "Clone a repository.",
           "id": "de7fda5bf07c49c938ba8ec46aa2c74d90d0b91b"
         },
         {
-          "title": "Ignore files",
+          "title": "Ignore files.",
           "id": "61dbcb4b24575d906db7d56beaf67990cd7c43da"
         },
         {
-          "title": "Add a file to staging",
+          "title": "Add a file to staging.",
           "id": "8b0fa13d4be2a9047a6638ada5df3f5446b910a1"
         },
         {
-          "title": "Unstage a file",
+          "title": "Unstage a file.",
           "id": "029bb0a36d8c541234f095cfdbf91aff4e041fc0"
         },
         {
-          "title": "Check status",
+          "title": "Check status.",
           "id": "07adf97a76fb80c6d062a86e969f1f8e536ae098"
         },
         {
-          "title": "View a diff",
+          "title": "View a diff.",
           "id": "07280cb812da0f73e160408db068f256c3ca54ff"
         },
         {
-          "title": "Create a commit",
+          "title": "Create a commit.",
           "id": "cab73a959ee344204b0a6d9778d589c4298dd9d3"
         },
         {
-          "title": "Push to origin",
+          "title": "Push to origin.",
           "id": "d5e0ac52487cfd72e63521bb533e3fc50303cbb7"
         },
         {
-          "title": "Pull remote changes locally",
+          "title": "Pull remote changes locally.",
           "id": "9317aef511220d4d3eff822b944902cf106d170f"
         },
         {
-          "title": "Resolve a conflict",
+          "title": "Resolve a conflict.",
           "id": "62652b80837a3a7e62bafdc7e84074bc0d07af64"
         },
         {
-          "title": "Create a branch",
+          "title": "Create a branch.",
           "id": "6f9226a72e59a0aff51d2e20fc4fa469fbba3a67"
         },
         {
-          "title": "Merge a branch into master",
+          "title": "Merge a branch into master.",
           "id": "b266e5ee9abc14b84ef83f57a8bc0181cac49849"
         },
         {
-          "title": "Push to a remote branch",
+          "title": "Push to a remote branch.",
           "id": "869a32ef65f85ac040b6894ff1586f9080225608"
         },
         {
-          "title": "Rebase origin/master into a branch",
+          "title": "Rebase origin/master into a branch.",
           "id": "f8630df75551c450a81d9146ae2cf336b28ddf40"
         }
       ]
@@ -90,7 +90,7 @@
       "level": "intermediate",
       "resources": [
         {
-          "title": "Watch the Distributed Workflow gitcast.",
+          "title": "Watch the Distributed Workflow gitcast",
           "uri": "http://www.youtube.com/watch?v=KWNIKb6sftw",
           "id": "909e39cd2c41596f5a136fcbb5f0908f4ef7359e"
         },
@@ -100,34 +100,34 @@
           "id": "d4d8a6d0b6b4f3aace8bb05b82fe45519c715e71"
         },
         {
-          "title": "Read gitready articles that interest you.",
+          "title": "Read gitready articles that interest you",
           "uri": "http://gitready.com",
           "id": "1153773f1dc8a6fc28401d6229521f6f4efc4360"
         }
       ],
       "validations": [
         {
-          "title": "Add a remote",
+          "title": "Add a remote.",
           "id": "e73ff8a3257fddfdb8d70c6e616749011049a799"
         },
         {
-          "title": "Amend a commit",
+          "title": "Amend a commit.",
           "id": "e57ffdff9b978e7277616294b1fecaf0a5c83d25"
         },
         {
-          "title": "Show a commit by SHA hash",
+          "title": "Show a commit by SHA hash.",
           "id": "5ed6f83c795e2e62fc4e85cb4784bc98dd2e5929"
         },
         {
-          "title": "Stash changes",
+          "title": "Stash changes.",
           "id": "c747d75cac93cf73494bd41dca993609a188710c"
         },
         {
-          "title": "Squash commits",
+          "title": "Squash commits.",
           "id": "01ab03f52ba4de6bc879222feadbd176e506afc5"
         },
         {
-          "title": "Create a tag",
+          "title": "Create a tag.",
           "id": "c5a7c043820a51491c1c7e5ab82c466072ac2bbd"
         }
       ]
@@ -137,27 +137,27 @@
       "level": "advanced",
       "validations": [
         {
-          "title": "Cherry pick commits",
+          "title": "Cherry pick commits.",
           "id": "a3c6e5e1ce2a20ce04a037c183c601cd4df09f7f"
         },
         {
-          "title": "Reorder commits",
+          "title": "Reorder commits.",
           "id": "96da1ff5a56a07284a3f3a7a3b3cd063e4713a25"
         },
         {
-          "title": "Keep either file in merge conflicts",
+          "title": "Keep either file in merge conflicts.",
           "id": "4bc62c4d53f25650f756aeba1c451309d878f674"
         },
         {
-          "title": "Restore lost commits",
+          "title": "Restore lost commits.",
           "id": "28be17b579507c025c4b7f8c1f901acece7075aa"
         },
         {
-          "title": "Visualize commits differently using git log flags",
+          "title": "Visualize commits differently using git log flags.",
           "id": "a247e0af381fa3a38c00e91f81f170eebe720d80"
         },
         {
-          "title": "Visualize changes differently using git diff flags",
+          "title": "Visualize changes differently using git diff flags.",
           "id": "4b0667767888be1930d4c6cffec71980b661ccd3"
         }
       ]

--- a/trails/heroku.json
+++ b/trails/heroku.json
@@ -30,11 +30,11 @@
       ],
       "validations": [
         {
-          "title": "Write a Procfile",
+          "title": "Write a Procfile.",
           "id": "227f8f8cb2c281fae790fbd4dcdeaf0c72a72d03"
         },
         {
-          "title": "Store secrets and environmental variables in config vars",
+          "title": "Store secrets and environmental variables in config vars.",
           "id": "3d0dc5337d810f869dda2830ad7599f4674176f5"
         },
         {
@@ -42,11 +42,11 @@
           "id": "7c3a314e09b51822b69748bca96da404f791f4c1"
         },
         {
-          "title": "Provision an add-on",
+          "title": "Provision an add-on.",
           "id": "65fa4796646f81f405808e0463b216d869296925"
         },
         {
-          "title": "Add a dyno to an app",
+          "title": "Add a dyno to an app.",
           "id": "8e0ebacf01b2eb21a2f5ca96fb36cdbf3b69f4d3"
         }
       ]
@@ -73,27 +73,27 @@
       ],
       "validations": [
         {
-          "title": "Understand the worker pattern",
+          "title": "Understand the worker pattern.",
           "id": "0e88dcb500d8c65147c41ca663cbce7914c25b71"
         },
         {
-          "title": "Achieve dev-prod parity by using foreman locally",
+          "title": "Achieve dev-prod parity by using foreman locally.",
           "id": "1732e1fc69d5c56d84e4041b580954c758da936d"
         },
         {
-          "title": "Leverage Heroku logs as a source of visibility into app performance",
+          "title": "Leverage Heroku logs as a source of visibility into app performance.",
           "id": "f342dc8209adc62f28b2a02905759dc86c88f8a4"
         },
         {
-          "title": "Build an app with a concurrent web server",
+          "title": "Build an app with a concurrent web server.",
           "id": "35387c0d077273c8c6b8bc86d452402439900ef8"
         },
         {
-          "title": "Understand request queuing",
+          "title": "Understand request queuing.",
           "id": "d93af37f6f189d3640c3bf753303f1fe7af702f4"
         },
         {
-          "title": "Use a tool like New Relic to gain visibility into response time variability",
+          "title": "Use a tool like New Relic to gain visibility into response time variability.",
           "id": "a8dd9f056b751b1925c8d05662d93ae290df33d5"
         }
       ]

--- a/trails/html-css.json
+++ b/trails/html-css.json
@@ -48,19 +48,19 @@
           "id": "a3fe4879dff7eda0935d70e57fca2c90dc39b519"
         },
         {
-          "title": "Understand the box model",
+          "title": "Understand the box model.",
           "id": "06658a0fd0bba774024bf850bf2145b177732ef7"
         },
         {
-          "title": "Understand floating and positioning",
+          "title": "Understand floating and positioning.",
           "id": "75a16c2513757729174e1aabb4d9f92a8f1f8708"
         },
         {
-          "title": "Style text",
+          "title": "Style text.",
           "id": "f6c26587c3d382fc5aa9ecd6fe16a23b8d145244"
         },
         {
-          "title": "Quickly build a simple layout",
+          "title": "Quickly build a simple layout.",
           "id": "60c527c909e214b60bcd5d7625c3f2d879a6e725"
         }
       ]
@@ -87,35 +87,35 @@
           "id": "16fabbaf7a203c9c764a0d5474a7f8baff0a81bb"
         },
         {
-          "title": "Understand the difference between <section> and <div>",
+          "title": "Understand the difference between <section> and <div>.",
           "id": "08ab12444e0607ecd1543551bb9ecedef26629c7"
         },
         {
-          "title": "Know all of the new form input types and if used how to safely degrade them to older browsers",
+          "title": "Know all of the new form input types and if used how to safely degrade them to older browsers.",
           "id": "ddc0dcd3a995cb4f5cea734841a73af061c4b549"
         },
         {
-          "title": "Apply a box shadow, rounded corners, and text shadow",
+          "title": "Apply a box shadow, rounded corners, and text shadow.",
           "id": "716ec582fb914e453001d74b175def2fb9cd112d"
         },
         {
-          "title": "Use RGBa, HSL, HSLa, and opacity",
+          "title": "Use RGBa, HSL, HSLa, and opacity.",
           "id": "a472be29ea68bada79c1255738bd9e06649b9d15"
         },
         {
-          "title": "Know transitions and animations and where to apply them",
+          "title": "Know transitions and animations and where to apply them.",
           "id": "d0d046d4e4db8b1544f78a6c611948a47e297f57"
         },
         {
-          "title": "Know what vendor prefixes are, why they are used",
+          "title": "Know what vendor prefixes are, why they are used.",
           "id": "3f2a3c791ac5c2993ca47d0b452be27eb3b68232"
         },
         {
-          "title": "Understand how box-sizing changes the box model",
+          "title": "Understand how box-sizing changes the box model.",
           "id": "3c4010eaa87bb3a1e1bfa2977109b3b7aab0a66c"
         },
         {
-          "title": "Know the new pseudo-selectors and know their uses",
+          "title": "Know the new pseudo-selectors and know their uses.",
           "id": "aecf8e1709cd0d7072fefd09c1b422664d7cb4a9"
         }
       ]
@@ -169,7 +169,7 @@
           "id": "01971d640fcadd447281de6625c1e1d9e9de3191"
         },
         {
-          "title": "Understand where breakpoints should be inserted into design",
+          "title": "Understand where breakpoints should be inserted into design.",
           "id": "ea0ee7c8e63533b284fcdd703cea7a44038b5b09"
         },
         {
@@ -181,7 +181,7 @@
           "id": "b3ab3fd91be55312acd85cb227ccc8844e4c5670"
         },
         {
-          "title": "Understand how best to serve images to mobile and retina screens",
+          "title": "Understand how best to serve images to mobile and retina screens.",
           "id": "fcaa691226b6b10f3f1ded6f2218ec974566aaa4"
         }
       ]

--- a/trails/ios.json
+++ b/trails/ios.json
@@ -169,7 +169,7 @@
           "id": "5856a49564090ea7557d03ea5ab8a0ce1167856b"
         },
         {
-          "title": "Implement a multi-tasking environment free of race conditions (using appropriate locking techniques such as mutexes and semaphores, message passing, etc)",
+          "title": "Implement a multi-tasking environment free of race conditions (using appropriate locking techniques such as mutexes and semaphores, message passing, etc).",
           "id": "f5c017d847a889fd4683e70babcc0ccb22c1f58c"
         },
         {

--- a/trails/javascript.json
+++ b/trails/javascript.json
@@ -158,7 +158,7 @@
           "id": "19b1659cb283f8a8edd994203909cb7be4993502"
         },
         {
-          "title": "Conform to a style guide",
+          "title": "Conform to a style guide.",
           "id": "6d98b52811029f423d1e0b452428912d39134f28"
         }
       ]

--- a/trails/rails.json
+++ b/trails/rails.json
@@ -107,7 +107,7 @@
           "id": "c61a53596b1ca48160026a58f3fa86457f3b64c9"
         },
         {
-          "title": "Use partials, built-in Rails helpers, and custom helpers to clean up and reduce duplication in your view code",
+          "title": "Use partials, built-in Rails helpers, and custom helpers to clean up and reduce duplication in your view code.",
           "id": "3e61e588877778170e227a8e0f4f3733d02cf61c"
         },
         {
@@ -115,23 +115,23 @@
           "id": "8ec0cb3149674908b168e0b38f06125ae5e4a346"
         },
         {
-          "title": "Implement user authentication",
+          "title": "Implement user authentication.",
           "id": "e2eab61b6900d3f82a0636c77ce7cc141c50e737"
         },
         {
-          "title": "Use polymorphism to model your domain",
+          "title": "Use polymorphism to model your domain.",
           "id": "172dce24fa2046daae1114b77255a72e89251ded"
         },
         {
-          "title": "Implement counter caches and advanced counters",
+          "title": "Implement counter caches and advanced counters.",
           "id": "a5689d588c3e29d85a48b8acacd1535d54247d38"
         },
         {
-          "title": "Implement file uploads",
+          "title": "Implement file uploads.",
           "id": "2017bc19194c261ad7fd97fc46225c77fd12691c"
         },
         {
-          "title": "Add pagination to your application",
+          "title": "Add pagination to your application.",
           "id": "577f80be46bca5d04258fbbe73d68e2e1df91bf9"
         }
       ]
@@ -177,11 +177,11 @@
           "id": "638a81cc8fccd7cf0289f6a048d9f61d264615cf"
         },
         {
-          "title": "Contribute to an open source project",
+          "title": "Contribute to an open source project.",
           "id": "14fb151241cc785f4dc76f88cc469bcb76a9b124"
         },
         {
-          "title": "Stick to a style guide",
+          "title": "Stick to a style guide.",
           "id": "30021911ea5e24ba77fcdb475414c4085c923147"
         }
       ]

--- a/trails/ruby.json
+++ b/trails/ruby.json
@@ -17,19 +17,19 @@
           "id": "cde6cffce2d06a3989ab936986311043afef9261"
         },
         {
-          "title": "Read Learn Ruby The Hard Way.",
+          "title": "Read Learn Ruby The Hard Way",
           "uri": "http://ruby.learncodethehardway.org/book/",
           "id": "5909ddee7e9b4e2233ea432599d3b280df7b2630"
         },
         {
-          "title": "Read The Well-Grounded Rubyist.",
+          "title": "Read The Well-Grounded Rubyist",
           "uri": "http://amzn.to/grounded-rubyist",
           "id": "c3dd3f0bdfb78932257723150ad2d59c6a691e3b",
           "publisher": "http://www.manning.com/black2/",
           "ibook": "itms-books://itunes.apple.com/us/book/the-well-grounded-rubyist/id402503392?mt=11"
         },
         {
-          "title": "Read Why's Poignant Guide.",
+          "title": "Read Why's Poignant Guide",
           "uri": "http://mislav.uniqpath.com/poignant-guide/book/chapter-1.html",
           "id": "17d73c796447dbbd7afa5896da547c7fd0968af0"
         }
@@ -70,12 +70,12 @@
       "level": "intermediate",
       "resources": [
         {
-          "title": "Complete the Ruby Koans.",
+          "title": "Complete the Ruby Koans",
           "uri": "http://rubykoans.com",
           "id": "1401fe762852bde4c44a57e752c3bce012f19e5a"
         },
         {
-          "title": "Read examples of source code, like this one.",
+          "title": "Read examples of source code, like this one",
           "uri": "https://github.com/jferris/effigy/tree/master/lib",
           "id": "fc5c572c0fd945a7b5d4025f9d29531714a385c0"
         },

--- a/trails/tmux.json
+++ b/trails/tmux.json
@@ -33,27 +33,27 @@
       ],
       "validations": [
         {
-          "title": "Attach, detach, and reattach to a session",
+          "title": "Attach, detach, and reattach to a session.",
           "id": "283ffb0b724711051276f05fcf14587e03ffdb67"
         },
         {
-          "title": "Create, switch, and close windows",
+          "title": "Create, switch, and close windows.",
           "id": "dd3ff2a531b6b2b9349d5d1c883837d0ccc6223e"
         },
         {
-          "title": "Rename windows",
+          "title": "Rename windows.",
           "id": "31db613c8ca08d5f3bf44f7a1603b43b14617ffc"
         },
         {
-          "title": "Split panes vertically and horizontally",
+          "title": "Split panes vertically and horizontally.",
           "id": "fb3ee555344e99ca7acde98200a577b7a2201629"
         },
         {
-          "title": "Switch and close panes",
+          "title": "Switch and close panes.",
           "id": "25136fd0a5a05223e97f6eac2550a33876b1e6fa"
         },
         {
-          "title": "Resize and rotate panes",
+          "title": "Resize and rotate panes.",
           "id": "648035715b2546327401d97f75f9b44ed62b251c"
         }
       ]

--- a/trails/unix.json
+++ b/trails/unix.json
@@ -25,7 +25,7 @@
       ],
       "validations": [
         {
-          "title": "You can use these commands and operators: |, <, >, >>, &, ack, awk, cat, chmod, chown, cp, export, find, kill, locate, ls, mkdir, mv, ps, rm, sed, sort, tail, top, vim, whereis, xargs",
+          "title": "You can use these commands and operators: |, <, >, >>, &, ack, awk, cat, chmod, chown, cp, export, find, kill, locate, ls, mkdir, mv, ps, rm, sed, sort, tail, top, vim, whereis, xargs.",
           "id": "ba03a2224008f4078b941e61050f7623164372b9"
         }
       ]

--- a/trails/visual-principles.json
+++ b/trails/visual-principles.json
@@ -13,13 +13,13 @@
           "type": "workshop"
         },
         {
-          "title": "Read 'Visual Grammar' for a basic understanding on basic elements of design and how they relate to each other.",
+          "title": "Read 'Visual Grammar' for a basic understanding on basic elements of design and how they relate to each other",
           "uri": "http://amzn.to/visual-grammar",
           "id": "cbee22bf1a60ae0906a63c2fb9c777d269c049b1",
           "publisher": "http://www.papress.com/html/book.details.page.tpl?isbn=9781568985817"
         },
         {
-          "title": "Read 'Universal Principles of Design' for a larger array of principles covering an array of medium.",
+          "title": "Read 'Universal Principles of Design' for a larger array of principles covering an array of medium",
           "uri": "http://amzn.to/universal-principles",
           "id": "a93aafbb4d3a2ebbdbb9971976bde5d9bfbb6cfd",
           "publisher": "http://stuffcreators.com/upod/"
@@ -39,7 +39,7 @@
           "id": "99a39199e94a0d32dc63098544cf2c057aaa1b6e"
         },
         {
-          "title": "Point out what visual principles, in any medium, that are being used in a design and why they are helping the design be successful or unsuccessful",
+          "title": "Point out what visual principles, in any medium, that are being used in a design and why they are helping the design be successful or unsuccessful.",
           "id": "23deeceac68bd161cd30d8adb62071e377672c1f"
         }
       ]

--- a/trails/web-design.json
+++ b/trails/web-design.json
@@ -60,15 +60,15 @@
           "id": "ce34e8b7ba9d4b47fa87c3a753f6e0d79358144e"
         },
         {
-          "title": "Create hierarchy within the design and type",
+          "title": "Create hierarchy within the design and type.",
           "id": "76a0c1c8e7d905e7a5f17383c11f25101f2bca4b"
         },
         {
-          "title": "Design a layout that is flexible and changes based on screen size",
+          "title": "Design a layout that is flexible and changes based on screen size.",
           "id": "5a12ca3dc4f1e2cca660490ab368568d3912f74c"
         },
         {
-          "title": "Understand the challenges and differences for designing for the web",
+          "title": "Understand the challenges and differences for designing for the web.",
           "id": "6222daae4d36269071bc9b12593a01f6d44a1053"
         },
         {


### PR DESCRIPTION
I was browsing through trails on trail-maps and noticed that the majority of the trails after Ruby had all of the links under 'resources' omitting the period, and all of the links under validations containing a period.  So, I went through and added periods to all validations without one and took out periods under all resources that weren't supposed to have one so that everything is uniform now.
