### PR TITLE
Fix and rename some items on the iOS trail map

### DIFF
--- a/trails/ios.json
+++ b/trails/ios.json
@@ -7,7 +7,7 @@
       "level": "beginner",
       "resources": [
         {
-          "title": "Read The Objective-C Programming Language",
+          "title": "Read Programming with Objective-C",
           "uri": "http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjectiveC/Introduction/introObjectiveC.html",
           "id": "26341a776d7f624192cdb428fded5478c934f6b5"
         },


### PR DESCRIPTION
The link to the HIG was broken, and 'The Objective-C Programming Language' guide has been renamed by Apple.

'Learning Objective-C: A Primer' is also gone entirely from the dev center, I assume to be replaced by 'The Objective-C Programming Language'.
