### PR TITLE
Remove Learn for iOS from the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ NOTE:
 
 As of 11/13/2012, this is now a JSON-only data resource.
 
-To browse the trails, download [Learn for iPhone and
-iPad](http://www.appstore.com/thoughtbotlearn) in the App Store or visit
-[learn.thoughtbot.com](https://learn.thoughtbot.com).
+To browse the trails, visit [learn.thoughtbot.com](https://learn.thoughtbot.com).
 
 Trail map
 =========


### PR DESCRIPTION
Learn for iOS was still linked to in the readme, but it's no longer on the App Store.
