### PR TITLE
Removes hgroup from the list of HTML5 elements

### DIFF
--- a/trails/html-css.json
+++ b/trails/html-css.json
@@ -83,7 +83,7 @@
       ],
       "validations": [
         {
-          "title": "Use the new HTML5 elements <header>, <hgroup>, <section>, <aside>, <article>, <footer> semantically.",
+          "title": "Use the new HTML5 elements <header>, <section>, <aside>, <article>, <footer> semantically.",
           "id": "16fabbaf7a203c9c764a0d5474a7f8baff0a81bb"
         },
         {


### PR DESCRIPTION
<hgroup> has been removed from the HTML5 specification and should probably not be listed here.

Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
